### PR TITLE
Fix error in clock process argument serialization

### DIFF
--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -4,7 +4,7 @@ require File.expand_path('../../config/environment', __FILE__)
 module Clockwork
   every(20.seconds, 'UpdateBusLocations') do
     District.find_each do |district|
-      UpdateBusLocationsJob.perform_later(district, since: 30.seconds.ago)
+      UpdateBusLocationsJob.perform_later(district, since: 30.seconds.ago.to_i)
     end
   end
 end

--- a/spec/jobs/api/v0/import_assignments_job_spec.rb
+++ b/spec/jobs/api/v0/import_assignments_job_spec.rb
@@ -9,7 +9,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '789', bus_identifier: 'ABC' }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Bus.count).to be 2
     expect(Student.count).to be 3
@@ -29,7 +29,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '123', bus_identifier: 'DEF' }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Bus.count).to be 2
     expect(Student.count).to be 1
@@ -52,7 +52,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '456', bus_identifier: nil }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Bus.count).to be 1
     expect(Student.count).to be 2
@@ -79,7 +79,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '123', bus_identifier: 'ABC' }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Bus.count).to be 2
     expect(Student.count).to be 2
@@ -103,7 +103,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '123', bus_identifier: 'ABC' }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Student.count).to be 1
     expect(BusAssignment.count).to be 1
@@ -113,7 +113,7 @@ describe API::V0::ImportAssignmentsJob do
   it 'does not unassign students if the input is empty' do
     student = create(:student, digest: '123', current_bus: create(:bus))
 
-    subject.perform(district: student.district, assignments: [])
+    described_class.perform_later(district: student.district, assignments: [])
 
     expect(student.bus_assignments.count).to be 1
     expect(student.current_bus_assignment.bus).to_not be nil
@@ -131,7 +131,7 @@ describe API::V0::ImportAssignmentsJob do
       { sha: '123', bus_identifier: 'XYZ' }
     ]
 
-    subject.perform(district: district, assignments: assignments)
+    described_class.perform_later(district: district, assignments: assignments)
 
     expect(Bus.count).to be 3
     expect(Student.count).to be 1


### PR DESCRIPTION
ActiveJob doesn't like serializing `Time` objects (or really anything aside from primitive values, persisted ActiveModel instances, and arrays/hashes that contain those object types).
