### PR TITLE
Use the correct subdomain part for district lookup

### DIFF
--- a/app/controllers/api/districts_controller.rb
+++ b/app/controllers/api/districts_controller.rb
@@ -1,7 +1,7 @@
 module API
   class DistrictsController < BaseController
     def show
-      respond_with District.find_by!(slug: request.subdomain)
+      respond_with District.find_by!(slug: request.subdomains.first)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,12 +10,12 @@ class User < ActiveRecord::Base
     :trackable,
     :validatable,
     :lockable,
-    request_keys: [:subdomain]
+    request_keys: [:subdomains]
 
   before_save :ensure_authentication_token
 
   def self.find_for_authentication(conditions)
-    district = District.find_by!(slug: conditions.delete(:subdomain))
+    district = District.find_by!(slug: conditions.delete(:subdomains).first)
     find_first_by_auth_conditions(conditions, district_id: district.id)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ describe User do
         .with({ email: 'test' }, district_id: district.id)
         .and_return('found!')
 
-      result = User.find_for_authentication(email: 'test', subdomain: 'foo')
+      result = User.find_for_authentication(email: 'test', subdomains: ['foo'])
 
       expect(result).to eq 'found!'
     end


### PR DESCRIPTION
`request.subdomain` arbitrarily returns the entire domain name excluding the last two parts, so the subdomain of "boston.staging.schoolbot.io" is considered to be "boston.staging".
