### PR TITLE
Install ember-watson and apply recommended changes

### DIFF
--- a/client/app/components/bus-map.js
+++ b/client/app/components/bus-map.js
@@ -30,7 +30,7 @@ export default LeafletMap.extend({
     attributionControl: false
   },
 
-  didCreateLayer: function() {
+  didCreateLayer() {
     this._super();
     L.control.attribution({ prefix: false })
       .addAttribution(ATTRIBUTION)
@@ -62,7 +62,7 @@ export default LeafletMap.extend({
         })
       }),
 
-      didCreateLayer: function() {
+      didCreateLayer() {
         this._super();
         // TODO: Higher-level default bound that takes the user's home address
         // and school addresses into account

--- a/client/app/components/locale-picker.js
+++ b/client/app/components/locale-picker.js
@@ -22,9 +22,9 @@ export default Ember.Component.extend({
   isOpen: false,
 
   actions: {
-    toggle: function() { this.toggleProperty('isOpen'); },
+    toggle() { this.toggleProperty('isOpen'); },
 
-    setLocale: function(locale) {
+    setLocale(locale) {
       this.get('i18n').set('locale', locale);
       this.get('localStorage').set('locale', locale);
       this.send('toggle');

--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   districts: Ember.inject.service(),
 
   actions: {
-    signOut: function() {
+    signOut() {
       this.get('session').invalidate();
     }
   }

--- a/client/app/controllers/index.js
+++ b/client/app/controllers/index.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    toggleProfile: function() {
+    toggleProfile() {
       this.toggleProperty('showingProfile');
     },
 
-    toggleAddStudent: function() {
+    toggleAddStudent() {
       this.toggleProperty('showingAddStudentForm');
     }
   }

--- a/client/app/controllers/sign-in.js
+++ b/client/app/controllers/sign-in.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   actions: {
-    signIn: function() {
+    signIn() {
       const credentials = this.getProperties('identification', 'password');
       this.get('session')
         .authenticate('simple-auth-authenticator:devise', credentials)

--- a/client/app/models/bus-location.js
+++ b/client/app/models/bus-location.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  bus: DS.belongsTo('bus'),
+  bus: DS.belongsTo('bus', { async: false }),
 
   latitude: DS.attr('number'),
   longitude: DS.attr('number'),

--- a/client/app/models/bus.js
+++ b/client/app/models/bus.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  busLocations: DS.hasMany('bus-location'),
-  students: DS.hasMany('student'),
+  busLocations: DS.hasMany('bus-location', { async: false }),
+  students: DS.hasMany('student', { async: false }),
 
   identifier: DS.attr('string'),
 

--- a/client/app/models/district.js
+++ b/client/app/models/district.js
@@ -1,8 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  schools: DS.hasMany('school'),
-  users: DS.hasMany('user'),
+  schools: DS.hasMany('school', { async: false }),
 
   name: DS.attr('string'),
   contactPhone: DS.attr('string'),

--- a/client/app/models/school.js
+++ b/client/app/models/school.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  district: DS.belongsTo('district'),
+  district: DS.belongsTo('district', { async: false }),
 
   name: DS.attr('string'),
   address: DS.attr('string'),

--- a/client/app/models/student.js
+++ b/client/app/models/student.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  bus: DS.belongsTo('bus'),
-  school: DS.belongsTo('school'),
+  bus: DS.belongsTo('bus', { async: false }),
+  school: DS.belongsTo('school', { async: false }),
 
   nickname: DS.attr('string'),
 

--- a/client/app/models/user.js
+++ b/client/app/models/user.js
@@ -1,8 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  district: DS.belongsTo('district'),
-
   email: DS.attr('string'),
   password: DS.attr('string'),
   passwordConfirmation: DS.attr('string'),

--- a/client/app/routes/application.js
+++ b/client/app/routes/application.js
@@ -10,7 +10,7 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
 
   title: t('titles.application'),
 
-  beforeModel: function() {
+  beforeModel() {
     this._super(...arguments);
 
     const storedLocale = this.get('localStorage.locale');

--- a/client/app/routes/index.js
+++ b/client/app/routes/index.js
@@ -4,7 +4,7 @@ import AuthenticatedRoute from 'simple-auth/mixins/authenticated-route-mixin';
 export default Ember.Route.extend(AuthenticatedRoute, {
   districts: Ember.inject.service(),
 
-  beforeModel: function() {
+  beforeModel() {
     if (!this.get('districts.current')) {
       this.transitionTo('about');
     } else {
@@ -12,12 +12,12 @@ export default Ember.Route.extend(AuthenticatedRoute, {
     }
   },
 
-  afterModel: function() {
+  afterModel() {
     this.students = this.store.findAll('student');
     return this.students;
   },
 
-  setupController: function(controller) {
+  setupController(controller) {
     controller.set('students', this.students);
   }
 });

--- a/client/app/services/districts.js
+++ b/client/app/services/districts.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Service.extend({
   store: Ember.inject.service(),
 
-  setup: function(){
+  setup() {
     return this.get('store').findRecord('district', 'current')
       .then((district) => this.set('current', district))
       .catch(() => null);

--- a/client/app/services/local-storage.js
+++ b/client/app/services/local-storage.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Service.extend({
-  unknownProperty: function(key) {
+  unknownProperty(key) {
     return localStorage.getItem(key);
   },
 
-  setUnknownProperty: function(key, value) {
+  setUnknownProperty(key, value) {
     if (value != null) {
       localStorage.setItem(key, value);
     } else {

--- a/client/app/services/translations.js
+++ b/client/app/services/translations.js
@@ -4,7 +4,7 @@ import { request } from 'ic-ajax';
 export default Ember.Service.extend({
   i18n: Ember.inject.service(),
 
-  setup: function() {
+  setup() {
     return request('/api/translations').then((locales) => {
       Object.keys(locales).forEach((locale) => {
         this.get('i18n').addTranslations(locale, locales[locale]);

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "ember-export-application-global": "1.0.3",
     "ember-i18n": "4.1.1",
     "ember-leaflet": "git://github.com/gabesmed/ember-leaflet.git#3d6d04d8feb16e73f8c833aec88b7fde09d978d8",
-    "ember-normalize": "0.0.4"
+    "ember-normalize": "0.0.4",
+    "ember-watson": "0.6.2"
   }
 }


### PR DESCRIPTION
- Use shorter ES6 method syntax
- Explicitly apply `async: false` to associations that lack the option (fixes deprecation warnings)

Also remove some associations that didn't make sense.
