### PR TITLE
Add district contact submission on main landing page

### DIFF
--- a/client/app/components/main-landing.js
+++ b/client/app/components/main-landing.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+import { request } from 'ic-ajax';
+
+export default Ember.Component.extend({
+  districtContactEmail: '',
+  districtContactInFlight: false,
+  districtContactSubmitted: false,
+  districtContactErrored: false,
+
+  actions: {
+    submitDistrictContact() {
+      this.set('districtContactErrored', false);
+
+      if (Ember.isPresent(this.get('districtContactEmail'))) {
+        this.set('districtContactInFlight', true);
+
+        request({
+          url: 'https://formspree.io/schoolbot-contact@vermonster.com',
+          method: 'POST',
+          dataType: 'json',
+          data: {
+            _replyto: this.get('districtContactEmail'),
+            _subject: 'District contact by ' + this.get('districtContactEmail')
+          }
+        }).then(() => {
+          this.set('districtContactSubmitted', true);
+        }).catch(() => {
+          this.set('districtContactErrored', true);
+        }).finally(() => {
+          this.set('districtContactInFlight', false);
+        });
+      }
+    }
+  }
+});

--- a/client/app/templates/components/main-landing.hbs
+++ b/client/app/templates/components/main-landing.hbs
@@ -12,8 +12,17 @@
   <div class='about__content about__content--district'>
     <h1>District</h1>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere mi quis libero hendrerit, eget pulvinar felis sagittis. Suspendisse ac nisi tempus, vehicula felis id, bibendum est. Nullam ac urna in justo convallis consectetur vel in lorem. Donec at ipsum id orci commodo ultricies at in felis. Phasellus eget sapien nibh. Praesent ac lacus nec ligula aliquet eleifend in nec tellus. Quisque mollis sed dui at efficitur. Suspendisse luctus mattis velit, sit amet blandit sapien fringilla vitae. Fusce faucibus ante sem, at mattis ex vestibulum ut.</p>
-    {{input class='about__input about__input--district' placeholder='email here'}}
-    <button class='about__cta about__cta--district' type='submit'>Submit</button>
+    {{#if districtContactSubmitted}}
+      <p>Thanks for your interest – we'll be in touch soon!</p>
+    {{else}}
+      <form {{action 'submitDistrictContact' on='submit'}}>
+        {{input value=districtContactEmail class='about__input about__input--district' placeholder='Enter your email address'}}
+        <button class='about__cta about__cta--district' type='submit' disabled={{districtContactInFlight}}>Submit</button>
+      </form>
+      {{#if districtContactErrored}}
+        <p>There was a problem submitting your email. Check your network connection and try again, or <a href="mailto:schoolbot-contact@vermonster.com?subject=SchoolBot information request">email us directly</a>.</p>
+      {{/if}}
+    {{/if}}
   </div>
 </section>
 


### PR DESCRIPTION
This is temporary until we get a real user/prospect communication solution in place, hence the lack of testing. The fallback ensures districts can still email us directly if something goes wrong.
