### PR TITLE
Replace app copy with 18n tokens

### DIFF
--- a/client/app/templates/components/add-student.hbs
+++ b/client/app/templates/components/add-student.hbs
@@ -1,7 +1,7 @@
 <form class='form--add-student'>
   {{student-fields errors=student.errors schools=schools update='update'}}
   <div class='button-group'>
-    <button class='form__cta--save' {{action 'save'}}>Save</button>
-    <button class='form__cta--cancel' {{action 'cancel'}}>Cancel</button>
+    <button class='form__cta--save' {{action 'save'}}>{{ t 'actions.save' }}</button>
+    <button class='form__cta--cancel' {{action 'cancel'}}>{{ t 'actions.cancel' }}</button>
   </div>
 </form>

--- a/client/app/templates/components/create-account.hbs
+++ b/client/app/templates/components/create-account.hbs
@@ -3,18 +3,18 @@
     {{#link-to 'index' class='form__title__back-cta' title='Back to district landing page'}}
       {{fa-icon 'chevron-left'}}
     {{/link-to}}
-    <h1 class='form__title--main'>Registration</h1>
+    <h1 class='form__title--main'>{{ t 'createAccount.title' }}</h1>
   </div>
   <fieldset class='form__section'>
-    <legend class='form__section-heading'>My Information</legend>
+    <legend class='form__section-heading'>{{ t 'createAccount.heading' }}</legend>
 
     {{profile-fields model=registration}}
   </fieldset>
 
   <fieldset class='form__section'>
-    <legend class='form__section-heading'>Student Information</legend>
+    <legend class='form__section-heading'>{{ t 'createAccount.studentInformation.heading' }}</legend>
 
-    <p>To register for SchoolBot, you must be the legal guardian of at least one student in this school district.</p>
+    <p>{{ t 'createAccount.studentInformation.copy' }}</p>
 
     {{student-fields errors=registration.errors schools=schools update='updateStudent'}}
   </fieldset>
@@ -31,8 +31,8 @@
         </span>
       {{/if}}
 
-      <button class='form__submit-cta' type="submit">Create account and login</button>
+      <button class='form__submit-cta' type="submit">{{ t 'createAccount.cta' }}</button>
     </div>
-    {{#link-to 'index' class='form__link--cancel'}}Cancel{{/link-to}}
+    {{#link-to 'index' class='form__link--cancel'}} {{ t 'actions.cancel' }} {{/link-to}}
   </section>
 </form>

--- a/client/app/templates/components/district-landing.hbs
+++ b/client/app/templates/components/district-landing.hbs
@@ -1,8 +1,8 @@
 {{#page-layout}}
   <div class='district'>
     <div class='district__title'>
-      <h1 class='district__title--main'>{{t 'district.title.main'}}</h1>
-      <h2 class='district__title--sub'>Presented by {{districts.current.name}}</h2>
+      <h1 class='district__title--main'>{{ t 'district.title' }}</h1>
+      <h2 class='district__title--sub'>{{districts.current.name}}</h2>
     </div>
     <section class='district__content'>
       <div class='district__logo'>
@@ -12,16 +12,16 @@
       {{locale-picker}}
 
       <p class='district__welcome-msg'>
-        {{t 'district.welcome.heading'}}
-        SchoolBot is an application that tells you when your child’s school bus is nearby.
+        {{ t 'district.welcome.heading' }}
+        {{ t 'district.welcome.message' }}
       </p>
 
       <p>
-        In order to use SchoolBot, you must be the parent or guardian of at least one child enrolled in the {{districts.current.name}}. You also need to have a unique ID number issued by your school district.
+        {{ t 'district.welcome.use' cityName=districts.current.name}}
       </p>
       <div class='button-group button-group--district'>
-        {{#link-to 'sign-in' class='district__cta--sign-in'}}Sign In{{/link-to}}
-        {{#link-to 'register' class='district__cta--register'}}Register{{/link-to}}
+        {{#link-to 'sign-in' class='district__cta--sign-in'}} {{ t 'actions.signIn' }} {{/link-to}}
+        {{#link-to 'register' class='district__cta--register'}} {{ t 'actions.register' }} {{/link-to}}
       </div>
     </section>
   </div>

--- a/client/app/templates/components/page-layout.hbs
+++ b/client/app/templates/components/page-layout.hbs
@@ -1,6 +1,6 @@
 <div class='main__outer--page-view'>
   <div class='main__content'>
-    <div class='logo'>Schoolbot</div>
+    <div class='logo'>{{ t 'titles.application' }}</div>
 
     {{yield}}
 

--- a/client/app/templates/components/profile-fields.hbs
+++ b/client/app/templates/components/profile-fields.hbs
@@ -1,6 +1,6 @@
 <div class='form__item {{if model.errors.name 'form__item--error'}}'>
   <label>
-    Full Name
+    {{ t 'labels.name'}}
     {{input value=model.name}}
   </label>
   {{#if model.errors.name}}
@@ -12,7 +12,7 @@
 
 <div class='form__item {{if model.errors.email 'form__item--error'}}'>
   <label>
-    Email
+    {{ t 'labels.email' }}
     {{input value=model.email}}
   </label>
   {{#if model.errors.email}}
@@ -25,7 +25,7 @@
 {{#if showingPasswordFields}}
   <div class='form__item {{if model.errors.password 'form__item--error'}}'>
     <label>
-      Password
+      {{ t 'labels.password' }}
       {{input type='password' value=model.password}}
     </label>
     {{#if model.errors.password}}
@@ -37,7 +37,7 @@
 
   <div class='form__item {{if model.errors.passwordConfirmation 'form__item--error'}}'>
     <label>
-      Confirm Password
+      {{ t 'labels.confirmPassword' }}
       {{input type='password' value=model.passwordConfirmation}}
     </label>
     {{#if model.errors.passwordConfirmation}}
@@ -53,32 +53,32 @@
   </a>
 {{/if}}
 
-<label>Address</label>
+<label>{{ t 'labels.address' }}</label>
 
 <div class='form__item {{if model.errors.street 'form__item--error'}}'>
   <label class='form__label--street'>
-    Street
+    {{ t 'labels.street' }}
     {{input value=model.street}}
   </label>
 </div>
 
 <div class='form__item {{if model.errors.city 'form__item--error'}}'>
   <label>
-    City
+    {{ t 'labels.city' }}
     {{input value=model.city}}
   </label>
 </div>
 
 <div class='form__item form__item--state {{if model.errors.name 'form__item--error'}}'>
   <label>
-    State
+    {{ t 'labels.state' }}
     {{input value=model.state}}
   </label>
 </div>
 
 <div class='form__item form__item--zip-code {{if model.errors.name 'form__item--error'}}'>
   <label>
-    ZIP Code
+    {{ t 'labels.zip' }}
     {{input value=model.zipCode}}
   </label>
 </div>

--- a/client/app/templates/components/student-fields.hbs
+++ b/client/app/templates/components/student-fields.hbs
@@ -1,7 +1,7 @@
 <fieldset>
   <div class='form__item {{if errors.school 'form__item--error'}}'>
     <label>
-      School
+      {{ t 'labels.school' }}
       {{#x-select  class='form__select--school' value=school}}
         <option value=''></option>
         {{#each orderedSchools as |school|}}
@@ -18,10 +18,10 @@
 
   <div class='form__item'>
     <label>
-      First Name
+      {{ t 'labels.nickname' }}
       {{input class='form__nickname' value=nickname}}
     </label>
-    <div class='form__note'>Your student’s position will be marked on the map with their nickname.</div>
+    <div class='form__note'>{{ t 'addStudent.nickname.note' }}</div>
     {{#if errors.school}}
       <span class='form__error--field'>
         {{t-error errors.nickname.firstObject}}
@@ -30,7 +30,7 @@
   </div>
 
   <fieldset class='form__fieldset--add-student'>
-    <div class='form__section-heading--encrypted'>This information is encrypted and used to look up your student with the school district. SchoolBot does not store it.</div>
+    <div class='form__section-heading--encrypted'>{{ t 'addStudent.encrypted' }}</div>
 
     {{#if errors.digest}}
       <span class='form__error--global'>
@@ -40,22 +40,22 @@
 
     <div class='form__item {{if errors.digest 'form__item--error'}}'>
       <label>
-        Last Name
+        {{ t 'labels.lastName' }}
         {{input value=lastName}}
       </label>
     </div>
 
     <div class='form__item {{if errors.digest 'form__item--error'}}'>
       <label>
-        Student ID Number
+        {{ t 'labels.identifier' }}
         {{input value=identifier}}
       </label>
-      <div class='form__note'>You should have received this number from your school district.</div>
+      <div class='form__note'>{{ t 'addStudent.identifier.note' }}</div>
     </div>
 
     <div class='form__item {{if birthdateIsValid '' 'form__item--error'}}'>
       <label>
-        Birthdate (MM/DD/YYYY)
+        {{ t 'labels.birthdate' }}
         {{input value=birthdate focus-out='validateBirthdate'}}
         {{#unless birthdateIsValid}}
           <span class='form__error--field'>

--- a/client/app/templates/map.hbs
+++ b/client/app/templates/map.hbs
@@ -4,16 +4,16 @@
   {{#if showingSettings}}
     <div class='modal modal__overlay'>
       <div class='modal__inner'>
-        <h2 class='modal__title'>Settings</h2>
+        <h2 class='modal__title'>{{ t 'map.settings' }}</h2>
         <button class='modal__close--title' {{action 'toggleSettings'}} aria-label='Close'></button>
         <div class='modal__body'>
           <section class='form__section'>
-            <h3 class='form__section-heading'>My Information</h3>
+            <h3 class='form__section-heading'>{{ t 'map.information' }}</h3>
             {{#if showingProfileForm}}
               {{profile-fields model=currentUser}}
               <div class='button-group button-group--edit-profile'>
-                <button class='form__cta--save' {{action 'updateProfile'}}>Save</button>
-                <button class='form__cta--cancel' {{action 'toggleEditProfile'}}>Cancel</button>
+                <button {{action 'updateProfile'}}>{{ t 'actions.save' }}</button>
+                <button {{action 'toggleEditProfile'}}>{{ t 'actions.cancel' }}</button>
               </div>
             {{else}}
               <a href='#' class='settings__edit-profile-cta' {{action 'toggleEditProfile'}}>
@@ -30,11 +30,11 @@
           </section>
 
           <section class='form__section'>
-            <h3 class='form__section-heading'>My Students</h3>
+            <h3 class='form__section-heading'>{{ t 'map.students' }}</h3>
             {{#unless showingStudentForm}}
               <a href='#' class='settings--add-student-cta' {{action 'toggleAddStudent'}}>
                 <span class='add-student-cta__icon'></span>
-                <span class='add-student-cta__text'>Add student</span>
+                <span class='add-student-cta__text'>{{ t 'actions.add' }}</span>
               </a>
             {{/unless}}
             {{#if showingStudentForm}}
@@ -61,9 +61,9 @@
             {{locale-picker}}
           </section>
 
-          <button class='modal__close' {{action 'toggleSettings'}}>Close</button>
+          <button class='modal__close' {{action 'toggleSettings'}}>{{ t 'actions.close' }}</button>
         </div>
-        <button class='modal__sign-out' {{action 'signOut'}}>Sign Out</button>
+        <button class='modal__sign-out' {{action 'signOut'}}>{{ t 'actions.signOut' }}</button>
       </div>
     </div>
   {{/if}}

--- a/client/app/templates/sign-in.hbs
+++ b/client/app/templates/sign-in.hbs
@@ -4,8 +4,8 @@
       {{#link-to 'index' class='form__title__back-cta' title='Back to district landing page'}}
         {{fa-icon 'chevron-left'}}
       {{/link-to}}
-      <h1 class='form__title--main'>Welcome Back!</h1>
-      <h2 class='form__title--sub'>Sign in to Schoolbot</h2>
+      <h1 class='form__title--main'>{{ t 'signIn.title.main' }}</h1>
+      <h2 class='form__title--sub'>{{ t 'signIn.title.sub' }}</h2>
     </div>
 
     {{#if errorMessage}}
@@ -17,14 +17,14 @@
     <div class='form__section'>
       <div class='form__item'>
         <label>
-          Your Email
+          {{ t 'labels.email' }}
           {{input class='sign-in__form-field' value=identification}}
         </label>
       </div>
 
       <div class='form__item'>
         <label>
-          Password
+          {{ t 'labels.password' }}
           {{input class='sign-in__form-field' type='password' value=password}}
         </label>
       </div>
@@ -32,18 +32,18 @@
       <div class='form__item'>
         <label class='form__remember-password'>
           {{input type='checkbox'}}
-          Remember me on this device
+          {{ t 'signIn.remember' }}
         </label>
       </div>
 
       <section class='form__section form__section--bottom'>
         <div class='form__item'>
-          <button class='form__submit-cta form__submit-cta--sign-in' type="submit">Sign In</button>
+          <button class='form__submit-cta form__submit-cta--sign-in' type="submit">{{ t 'actions.signIn' }}</button>
         </div>
 
         <div class='form__section--bottom__note'>
-          <a class='sign-in__forgot-password' href='#'>Forgot your username or password?</a>
-          {{#link-to 'register' class='sign-in__register-cta'}}Need to register an account?{{/link-to}}
+          <a class='sign-in__forgot-password' href='#'>{{ t 'signIn.forgot' }}</a>
+          {{#link-to 'register' class='sign-in__register-cta'}} {{ t 'signIn.needToRegister' }} {{/link-to}}
         </div>
       </section>
     </div>

--- a/config/locales/application.yml
+++ b/config/locales/application.yml
@@ -61,17 +61,78 @@ en:
       blank: Please select a school.
     session:
       invalid: Invalid email address or password.
+  labels:
+    name: Full Name
+    email: Email
+    password: Password
+    confirmPassword: Confirm Password
+    address: Address
+    street: Street
+    city: City
+    state: State
+    zip: ZIP Code
+    nickname: First Name
+    lastName: Last Name
+    identifier: Student ID Number
+    birthdate: Birthdate (MM/DD/YYYY)
+    school: School
+    termsAndConditions: I agree to the terms & conditions
+  actions:
+    signIn: Sign In
+    register: Register
+    save: Save
+    cancel: Cancel
+    edit: Edit
+    close: Close
+    signOut: Sign Out
+    add: Add student
+    changePassword: Change Password
   district:
-    title:
-      main: Welcome to Schoolbot
+    title: Welcome to Schoolbot
     welcome:
       heading: Welcome!
+      message: SchoolBot is an application that tells you when your child’s school bus is nearby.
+      use: |
+        In order to use SchoolBot, you must be the parent or guardian of at least one child enrolled in the
+        {{cityName}} school district. You also need to have a unique ID number issued by your school district.
+  createAccount:
+    title: Registration
+    heading: My Information
+    studentInformation:
+      heading: Student Information
+      copy: To register for SchoolBot, you must be the legal guardian of at least one student in this school district.
+    cta: Create account and login
+  addStudent:
+    nickname:
+      note: Your student’s position will be marked on the map with their nickname.
+    encrypted: |
+      This information is encrypted and used to look up your student with the school district.
+      SchoolBot does not store it.
+    identifier:
+      note: You should have received this number from your school district.
+  map:
+    settings: Settings
+    information: My Information
+    students: My Students
+  signIn:
+    title:
+      main: Welcome Back!
+      sub: Sign in to Schoolbot
+    remember: Remember me on this device
+    forgot: Forgot your username or password?
+    needToRegister: Need to register an account?
 
 es:
   <<: *common
   example: ¡Texto de ejemplo!
+  actions:
+    signIn: Sign In
+    register: Register
   district:
-    title:
-      main: Bienvenida a Schoolbot
+    title: Bienvenida a Schoolbot
     welcome:
       heading: Bienvenida!
+      message: Bienvenida! SchoolBot is an application that tells you when your child’s school bus is nearby.
+      use: |
+        Bienvenida! In order to use SchoolBot, you must be the parent or guardian of at least one child enrolled in the
+        {{cityName}} school district. You also need to have a unique ID number issued by your school district.

--- a/spec/features/landing_page_spec.rb
+++ b/spec/features/landing_page_spec.rb
@@ -6,7 +6,7 @@ feature 'Landing page' do
 
     visit root_path
 
-    expect(page).to have_content 'WELCOME'
+    expect(page).to have_content t('district.welcome.heading').upcase
   end
 
   scenario 'shows the district name and logo when accessed at a subdomain' do

--- a/spec/features/locale_picker_spec.rb
+++ b/spec/features/locale_picker_spec.rb
@@ -7,8 +7,8 @@ feature 'Locale picker' do
     select t('locales.en'), from: 'Language'
     select t('locales.es'), from: 'Language'
 
-    expect(page).to have_content t('district.title.main', locale: :es).upcase
-    expect(page).to_not have_content t('district.title.main', locale: :en).upcase
+    expect(page).to have_content t('district.title', locale: :es).upcase
+    expect(page).to_not have_content t('district.title', locale: :en).upcase
   end
 
   scenario 'remembers the selected locale across site visits' do
@@ -18,6 +18,6 @@ feature 'Locale picker' do
     select t('locales.es'), from: 'Language'
     visit root_path
 
-    expect(page).to have_content t('district.title.main', locale: :es).upcase
+    expect(page).to have_content t('district.title', locale: :es).upcase
   end
 end

--- a/spec/features/user_adds_student_spec.rb
+++ b/spec/features/user_adds_student_spec.rb
@@ -15,15 +15,14 @@ feature 'User adds student' do
     sign_in_as user
 
     find('[aria-label="Settings"]').click
-    click_on 'Add student'
-    fill_in 'First Name', with: 'Danny'
-    fill_in 'Last Name', with: 'Smith'
-    fill_in 'Student ID', with: 'A1234'
-    fill_in 'Birthdate', with: '5/27/2003'
-    select 'Springfield Elementary', from: 'School'
+    click_on t('actions.add')
+
+    fill_in_student_information
+
+    select 'Springfield Elementary', from: t('labels.school')
     click_on 'Save'
 
-    expect(page).to_not have_button 'Save'
+    expect(page).to_not have_button t('actions.save')
     within('section', text: 'MY STUDENTS') do
       within('li', text: 'Danny') do
         expect(page).to have_content 'DA'
@@ -44,14 +43,13 @@ feature 'User adds student' do
     sign_in_as user
 
     find('[aria-label="Settings"]').click
-    click_on 'Add student'
-    fill_in 'First Name', with: 'Danny'
-    fill_in 'Last Name', with: 'Smith'
-    fill_in 'Student ID', with: 'A1234'
-    fill_in 'Birthdate', with: '5/27/2003'
-    click_on 'Save'
+    click_on t('actions.add')
 
-    expect(page).to have_button 'Save'
+    fill_in_student_information
+
+    click_on t('actions.save')
+
+    expect(page).to have_button t('actions.save')
     expect(page).to have_content t('errors.digest.blank')
     expect(page).to have_content t('errors.nickname.taken')
     expect(page).to have_content t('errors.school.blank')
@@ -62,9 +60,16 @@ feature 'User adds student' do
     sign_in_as create(:user)
 
     find('[aria-label="Settings"]').click
-    click_on 'Add student'
-    fill_in 'Birthdate', with: '2003-05-27'
+    click_on t('actions.add')
+    fill_in t('labels.birthdate'), with: '2003-05-27'
 
     expect(page).to have_content t('errors.birthdate.invalid')
+  end
+
+  def fill_in_student_information
+    fill_in t('labels.nickname'), with: 'Danny'
+    fill_in t('labels.lastName'), with: 'Smith'
+    fill_in t('labels.identifier'), with: 'A1234'
+    fill_in t('labels.birthdate'), with: '5/27/2003'
   end
 end

--- a/spec/features/user_creates_account_spec.rb
+++ b/spec/features/user_creates_account_spec.rb
@@ -14,22 +14,22 @@ feature 'User creates account' do
     use_subdomain(district.slug)
 
     visit root_path
-    click_on 'Register'
-    fill_in 'Full Name', with: 'Guy Test'
-    fill_in 'Email', with: 'guy@example.com'
-    fill_in 'Password', with: 'secretpass'
-    fill_in 'Confirm Password', with: 'secretpass'
-    fill_in 'Street', with: '123 Main St'
-    fill_in 'City', with: 'Someplace'
-    fill_in 'State', with: 'MA'
-    fill_in 'ZIP Code', with: '12345'
-    fill_in 'First Name', with: 'Johnny'
-    fill_in 'Last Name', with: 'Test'
-    fill_in 'Student ID', with: 'ABC123'
-    fill_in 'Birthdate', with: '3/21/2002'
-    select 'Springfield High', from: 'School'
-    check 'I agree to the terms & conditions'
-    click_on 'Create account and login'
+    click_on t('actions.register')
+    fill_in t('labels.name'), with: 'Guy Test'
+    fill_in t('labels.email'), with: 'guy@example.com'
+    fill_in t('labels.password'), with: 'secretpass'
+    fill_in t('labels.confirmPassword'), with: 'secretpass'
+    fill_in t('labels.street'), with: '123 Main St'
+    fill_in t('labels.city'), with: 'Someplace'
+    fill_in t('labels.state'), with: 'MA'
+    fill_in t('labels.zip'), with: '12345'
+    fill_in t('labels.nickname'), with: 'Johnny'
+    fill_in t('labels.lastName'), with: 'Test'
+    fill_in t('labels.identifier'), with: 'ABC123'
+    fill_in t('labels.birthdate'), with: '3/21/2002'
+    select 'Springfield High', from: t('labels.school')
+    check t('labels.termsAndConditions')
+    click_on t('createAccount.cta')
 
     expect(page).to have_css 'button.btn--settings', wait: 5
     within('.leaflet-container') do
@@ -43,14 +43,14 @@ feature 'User creates account' do
     use_subdomain(district.slug)
 
     visit root_path
-    click_on 'Register'
-    fill_in 'Email', with: 'guy@example.com'
-    fill_in 'Password', with: 'secret'
-    fill_in 'Confirm Password', with: 'sorcret'
-    fill_in 'Last Name', with: 'Test'
-    fill_in 'Student ID', with: 'ABC123'
-    fill_in 'Birthdate', with: '2002-03-21'
-    click_on 'Create account and login'
+    click_on t('actions.register')
+    fill_in t('labels.email'), with: 'guy@example.com'
+    fill_in t('labels.password'), with: 'secret'
+    fill_in t('labels.confirmPassword'), with: 'sorcret'
+    fill_in t('labels.lastName'), with: 'Test'
+    fill_in t('labels.identifier'), with: 'ABC123'
+    fill_in t('labels.birthdate'), with: '2002-03-2'
+    click_on t('createAccount.cta')
 
     expect(page).to have_content t('errors.blank'), count: 1
     expect(page).to have_content t('errors.email.taken')
@@ -68,12 +68,12 @@ feature 'User creates account' do
     use_subdomain(create(:district).slug)
 
     visit root_path
-    click_on 'Register'
-    fill_in 'Street', with: '123 Main St'
-    fill_in 'City', with: 'Someplace'
-    fill_in 'State', with: 'MA'
-    fill_in 'ZIP Code', with: '12345'
-    click_on 'Create account and login'
+    click_on t('actions.register')
+    fill_in t('labels.street'), with: '123 Main St'
+    fill_in t('labels.city'), with: 'Someplace'
+    fill_in t('labels.state'), with: 'MA'
+    fill_in t('labels.zip'), with: '12345'
+    click_on t('createAccount.cta')
 
     expect(page).to have_content t('errors.address.invalid')
   end

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -14,10 +14,10 @@ feature 'User signs in' do
     use_subdomain('boston')
 
     visit root_path
-    click_on 'Sign In'
-    fill_in 'Your Email', with: 'bob@example.com'
-    fill_in 'Password', with: 'secretpass'
-    click_on 'Sign In'
+    click_on t('actions.signIn')
+    fill_in t('labels.email'), with: 'bob@example.com'
+    fill_in t('labels.password'), with: 'secretpass'
+    click_on t('actions.signIn')
 
     expect(page).to have_css 'button.btn--settings'
   end
@@ -26,10 +26,10 @@ feature 'User signs in' do
     use_subdomain('boston')
 
     visit root_path
-    click_on 'Sign In'
-    fill_in 'Your Email', with: 'bob@example.com'
-    fill_in 'Password', with: ''
-    click_on 'Sign In'
+    click_on t('actions.signIn')
+    fill_in t('labels.email'), with: 'bob@example.com'
+    fill_in t('labels.password'), with: ''
+    click_on t('actions.signIn')
 
     expect(page).to have_content t('errors.session.invalid')
   end
@@ -39,10 +39,10 @@ feature 'User signs in' do
     use_subdomain('district13')
 
     visit root_path
-    click_on 'Sign In'
-    fill_in 'Your Email', with: 'bob@example.com'
-    fill_in 'Password', with: 'secretpass'
-    click_on 'Sign In'
+    click_on t('actions.signIn')
+    fill_in t('labels.email'), with: 'bob@example.com'
+    fill_in t('labels.password'), with: 'secretpass'
+    click_on t('actions.signIn')
 
     expect(page).to have_content t('errors.session.invalid')
   end

--- a/spec/features/user_signs_out_spec.rb
+++ b/spec/features/user_signs_out_spec.rb
@@ -9,10 +9,10 @@ feature 'User signs out' do
     end
 
     within('.modal') do
-      click_on 'Sign Out'
+      click_on t('actions.signOut')
     end
 
-    expect(page).to have_content 'SIGN IN'
-    expect(page).to have_content 'REGISTER'
+    expect(page).to have_content t('actions.signIn').upcase
+    expect(page).to have_content t('actions.register').upcase
   end
 end

--- a/spec/features/user_updates_profile_spec.rb
+++ b/spec/features/user_updates_profile_spec.rb
@@ -5,18 +5,18 @@ feature 'User updates profile' do
     sign_in_as create(:user)
 
     find('[aria-label="Settings"]').click
-    click_on 'Edit'
-    fill_in 'Name', with: 'Guy Test'
-    fill_in 'Email', with: 'guy@example.com'
-    click_on 'Change Password'
-    fill_in 'Password', with: 'secretpass'
-    fill_in 'Confirm Password', with: 'secretpass'
-    fill_in 'Street', with: '123 Main St'
-    fill_in 'City', with: 'Someplace'
-    fill_in 'State', with: 'MA'
-    click_on 'Save'
+    click_on t('actions.edit')
+    fill_in t('labels.name'), with: 'Guy Test'
+    fill_in t('labels.email'), with: 'guy@example.com'
+    click_on t('actions.changePassword')
+    fill_in t('labels.password'), with: 'secretpass'
+    fill_in t('labels.confirmPassword'), with: 'secretpass'
+    fill_in t('labels.street'), with: '123 Main St'
+    fill_in t('labels.city'), with: 'Someplace'
+    fill_in t('labels.state'), with: 'MA'
+    click_on t('actions.save')
 
-    expect(page).to_not have_button 'Save'
+    expect(page).to_not have_button t('actions.save')
     within('section', text: 'MY INFORMATION') do
       expect(page).to have_content 'Guy Test'
       expect(page).to have_content 'guy@example.com'
@@ -32,13 +32,13 @@ feature 'User updates profile' do
     sign_in_as create(:user, district: district)
 
     find('[aria-label="Settings"]').click
-    click_on 'Edit'
-    fill_in 'Email', with: 'guy@example.com'
-    click_on 'Change Password'
-    fill_in 'Password', with: 'secret'
-    fill_in 'Confirm Password', with: 'sorcret'
-    fill_in 'Street', with: ''
-    click_on 'Save'
+    click_on t('actions.edit')
+    fill_in t('labels.email'), with: 'guy@example.com'
+    click_on t('actions.changePassword')
+    fill_in t('labels.password'), with: 'secret'
+    fill_in t('labels.confirmPassword'), with: 'sorcret'
+    fill_in t('labels.street'), with: ''
+    click_on t('actions.save')
 
     expect(page).to have_content t('errors.email.taken')
     expect(page).to have_content t('errors.password.too_short')

--- a/spec/support/features/sessions.rb
+++ b/spec/support/features/sessions.rb
@@ -2,9 +2,9 @@ module Sessions
   def sign_in_as(user)
     use_subdomain(user.district.slug)
     visit root_path
-    click_on 'Sign In'
-    fill_in 'Your Email', with: user.email
-    fill_in 'Password', with: user.password
-    click_on 'Sign In'
+    click_on t('actions.signIn')
+    fill_in t('labels.email'), with: user.email
+    fill_in t('labels.password'), with: user.password
+    click_on t('actions.signIn')
   end
 end


### PR DESCRIPTION
Covers:

https://trello.com/c/yGCNIS4M/98-localization-pass-i18n
- All copy used in the app interface, and in any emails the app generates, should be localizable using i18n tokens.
