### PR TITLE
Add circuit breaker for Zonar service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "active_model_serializers"
 gem "airbrake"
 gem "aws-sdk", "~> 1.6" # TODO: Remove constraint once Paperclip supports 2.0
 gem "bcrypt"
+gem "cb2"
 gem "clockwork"
 gem "delayed-plugins-airbrake"
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cb2 (0.0.3)
+      redis (~> 3.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -260,6 +262,7 @@ DEPENDENCIES
   bcrypt
   bundler-audit
   byebug
+  cb2
   clockwork
   database_cleaner
   delayed-plugins-airbrake

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -6,7 +6,7 @@ module Clockwork
     Airbrake.notify(error)
   end
 
-  every(20.seconds, 'UpdateBusLocations') do
+  every(Zonar::REQUEST_INTERVAL, 'UpdateBusLocations') do
     District.find_each do |district|
       UpdateBusLocationsJob.perform_later(district)
     end

--- a/spec/models/zonar_spec.rb
+++ b/spec/models/zonar_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Zonar do
+  describe '#bus_events_since' do
+    it 'raises an error with the customer ID if the breaker is open' do
+      allow(CB2::Breaker).to receive(:new).and_return(
+        CB2::Breaker.new(strategy: 'stub', allow: false)
+      )
+
+      zonar = Zonar.new(customer: 'test1234', username: 'a', password: 'b')
+
+      expect { zonar.bus_events_since(1.minute.ago) }
+        .to raise_error(CB2::BreakerOpen, 'Zonar customer: test1234')
+    end
+  end
+end


### PR DESCRIPTION
This prevents sporadic Zonar failures from clogging up Airbrake. If there is an actual outage, it will still be surfaced as a `BreakerOpen` error, and we'll fall back to less-frequent polling to avoid becoming part of the problem.
