### PR TITLE
Use sessionStorage instead of localStorage

### DIFF
--- a/client/app/components/locale-picker.js
+++ b/client/app/components/locale-picker.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export default Ember.Component.extend({
   i18n: Ember.inject.service(),
-  localStorage: Ember.inject.service(),
+  sessionStorage: Ember.inject.service(),
 
   classNames: ['locale-picker'],
 
@@ -19,7 +19,7 @@ export default Ember.Component.extend({
     setLocale(locale) {
       moment.locale(locale);
       this.get('i18n').set('locale', locale);
-      this.get('localStorage').set('locale', locale);
+      this.get('sessionStorage').set('locale', locale);
     }
   }
 });

--- a/client/app/routes/application.js
+++ b/client/app/routes/application.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 export default Ember.Route.extend(ApplicationRouteMixin, {
   districts: Ember.inject.service(),
   i18n: Ember.inject.service(),
-  localStorage: Ember.inject.service(),
+  sessionStorage: Ember.inject.service(),
   translations: Ember.inject.service(),
 
   title: t('titles.application'),
@@ -14,7 +14,7 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   beforeModel() {
     this._super(...arguments);
 
-    const storedLocale = this.get('localStorage.locale');
+    const storedLocale = this.get('sessionStorage.locale');
     if (Ember.isPresent(storedLocale)) {
       moment.locale(storedLocale);
       this.get('i18n').set('locale', storedLocale);

--- a/client/app/services/session-storage.js
+++ b/client/app/services/session-storage.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  unknownProperty(key) {
+    return sessionStorage.getItem(key);
+  },
+
+  setUnknownProperty(key, value) {
+    if (value != null) {
+      sessionStorage.setItem(key, value);
+    } else {
+      sessionStorage.removeItem(key);
+    }
+
+    this.notifyPropertyChange(key);
+    return value;
+  }
+});

--- a/client/app/stores/simple-auth-session.js
+++ b/client/app/stores/simple-auth-session.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import Base from 'simple-auth/stores/base';
+import objectsAreEqual from 'simple-auth/utils/objects-are-equal';
+
+export default Base.extend({
+  sessionStorage: Ember.inject.service(),
+
+  init: function() {
+    this.key = 'ember_simple_auth:session';
+    this.bindToStorageEvents();
+  },
+
+  persist: function(data) {
+    data = JSON.stringify(data || {});
+    this.get('sessionStorage').set(this.key, data);
+    this._lastData = this.restore();
+  },
+
+  restore: function() {
+    const data = this.get('sessionStorage').get(this.key);
+    return JSON.parse(data) || {};
+  },
+
+  clear: function() {
+    this.get('sessionStorage').set(this.key, null);
+    this._lastData = {};
+  },
+
+  bindToStorageEvents: function() {
+    Ember.$(window).bind('storage', () => {
+      const data = this.restore();
+      if (!objectsAreEqual(data, this._lastData)) {
+        this._lastData = data;
+        this.trigger('sessionDataUpdated', data);
+      }
+    });
+  }
+});

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -9,6 +9,7 @@ module.exports = function(environment) {
     i18n: { defaultLocale: 'en' },
     moment: { includeLocales: true },
     'simple-auth': {
+      store: 'store:simple-auth-session',
       authorizer: 'simple-auth-authorizer:devise',
       authenticationRoute: 'sign-in'
     },


### PR DESCRIPTION
Right now there is no mechanism to expire auth tokens, so users would be remembered forever until they explicitly signed out. This at least limits the "remembering" to the current session (which is destroyed on tab close).
