### PR TITLE
Use shortest distinct abbreviation for student nicknames

### DIFF
--- a/client/app/models/student.js
+++ b/client/app/models/student.js
@@ -11,8 +11,21 @@ export default DS.Model.extend({
   isAssigned: Ember.computed.notEmpty('bus'),
   isLocated: Ember.computed.alias('bus.hasLocations'),
 
-  // TODO: Calculate the shortest distinct abbreviation among all nicknames?
-  abbreviation: Ember.computed('nickname', function() {
-    return this.get('nickname').substr(0, 2).toUpperCase();
+  allStudents: Ember.computed(function() {
+    return this.store.peekAll('student');
+  }),
+  persistedStudents: Ember.computed.filterBy('allStudents', 'isNew', false),
+  abbreviation: Ember.computed('persistedStudents.@each.nickname', function() {
+    let length = 1;
+    for (; length < 3; length++) {
+      const abbreviationIsUnique =
+        this.get('persistedStudents').without(this).every((student) => {
+          const myAbbreviation = this.get('nickname').slice(0, length);
+          const otherAbbreviation = student.get('nickname').slice(0, length);
+          return myAbbreviation !== otherAbbreviation;
+        });
+      if (abbreviationIsUnique) { break; }
+    }
+    return this.get('nickname').slice(0, length);
   })
 });

--- a/spec/features/user_adds_student_spec.rb
+++ b/spec/features/user_adds_student_spec.rb
@@ -25,7 +25,7 @@ feature 'User adds student' do
     expect(page).to_not have_button t('actions.save')
     within('section', text: 'MY STUDENTS') do
       within('li', text: 'Danny') do
-        expect(page).to have_content 'DA'
+        expect(page).to have_css '.student__nickname', text: 'D'
         expect(page).to have_content 'Springfield Elementary'
       end
     end

--- a/spec/features/user_creates_account_spec.rb
+++ b/spec/features/user_creates_account_spec.rb
@@ -45,7 +45,7 @@ feature 'User creates account' do
       expect(page).to have_content t('flashes.success.accountConfirmed')
       expect(page).to have_css 'button.btn--settings'
       within('.leaflet-container') do
-        expect(page).to have_css('.bus-marker', text: 'JO')
+        expect(page).to have_css('.bus-marker', text: 'J')
       end
     end
   end

--- a/spec/features/user_views_map_spec.rb
+++ b/spec/features/user_views_map_spec.rb
@@ -33,16 +33,16 @@ feature 'User views map' do
 
       within('.leaflet-container') do
         expect(page).to have_css('.bus-marker', count: 2)
-        expect(page).to have_css('.bus-marker', text: 'FI')
-        expect(page).to have_css('.bus-marker', text: 'SE')
+        expect(page).to have_css('.bus-marker', text: 'F')
+        expect(page).to have_css('.bus-marker', text: 'S')
       end
     end
 
     scenario 'live-updated as locations change' do
       sign_in_as @user
 
-      first_bus_style = page.find('.bus-marker', text: 'FI')[:style]
-      second_bus_style = page.find('.bus-marker', text: 'SE')[:style]
+      first_bus_style = page.find('.bus-marker', text: 'F')[:style]
+      second_bus_style = page.find('.bus-marker', text: 'S')[:style]
 
       create(:bus_location, bus: @first_bus, latitude: 42.03)
 
@@ -61,7 +61,7 @@ feature 'User views map' do
 
     sign_in_as @user
 
-    expect(page).to have_css('.bus-marker', count: 1, text: 'FISE')
+    expect(page).to have_css('.bus-marker', count: 1, text: 'FS')
   end
 
   scenario 'with markers displayed only for buses with recent locations' do
@@ -74,7 +74,7 @@ feature 'User views map' do
 
     sign_in_as @user
 
-    expect(page).to have_css('.bus-marker', count: 1, text: 'FI')
+    expect(page).to have_css('.bus-marker', count: 1, text: 'F')
     expect(page).to have_content t('map.messages.missingStudents')
   end
 
@@ -85,7 +85,7 @@ feature 'User views map' do
 
     sign_in_as @user
 
-    expect(page).to have_css('.bus-marker', count: 1, text: 'SE')
+    expect(page).to have_css('.bus-marker', count: 1, text: 'S')
     expect(page).to have_content t('map.messages.missingStudents')
   end
 

--- a/spec/features/user_views_students_spec.rb
+++ b/spec/features/user_views_students_spec.rb
@@ -32,14 +32,27 @@ feature 'User views students' do
 
     within('section', text: 'MY STUDENTS') do
       within('li', text: 'First') do
-        expect(page).to have_content 'FI'
+        expect(page).to have_css '.student__nickname', text: 'F'
         expect(page).to have_content 'Middle School'
       end
       within('li', text: 'Second') do
-        expect(page).to have_content 'SE'
+        expect(page).to have_css '.student__nickname', text: 'S'
         expect(page).to have_content 'High School'
       end
     end
+  end
+
+  scenario 'and sees unique abbreviations for each student nickname' do
+    create(:student_label, user: @user, nickname: 'Bobby')
+    create(:student_label, user: @user, nickname: 'Benny')
+    create(:student_label, user: @user, nickname: 'Berky')
+
+    sign_in_as @user
+    click_on t('settings.title')
+
+    expect(page).to have_css '.student__nickname', text: 'Bo'
+    expect(page).to have_css '.student__nickname', text: 'Ben'
+    expect(page).to have_css '.student__nickname', text: 'Ber'
   end
 
   scenario 'and sees a message if no recent bus locations are available' do


### PR DESCRIPTION
Cleaning up a long-standing TODO. In most cases student abbreviations will now be just the first letter of the nickname, with extra letters added only to disambiguate students with the same first letter.
