### PR TITLE
Confirm all existing users on next deploy

### DIFF
--- a/db/migrate/20151118155406_confirm_all_existing_users.rb
+++ b/db/migrate/20151118155406_confirm_all_existing_users.rb
@@ -1,0 +1,9 @@
+class ConfirmAllExistingUsers < ActiveRecord::Migration
+  def up
+    User.where(confirmed_at: nil).update_all('confirmed_at = created_at')
+  end
+
+  def down
+    User.where('confirmed_at = created_at').update_all(confirmed_at: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116214541) do
+ActiveRecord::Schema.define(version: 20151118155406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This would otherwise prevent any users from signing in after the migration that adds confirmation attributes is deployed, since the confirmed_at column was not set for existing users.
