### PR TITLE
Allow districts to be set as "inactive"

### DIFF
--- a/app/controllers/concerns/current_district.rb
+++ b/app/controllers/concerns/current_district.rb
@@ -4,6 +4,7 @@ module CurrentDistrict
   private
 
   def current_district
-    @_current_district ||= District.find_by!(slug: request.subdomains.first)
+    @_current_district ||=
+      District.active.find_by!(slug: request.subdomains.first)
   end
 end

--- a/app/controllers/concerns/district_authenticated.rb
+++ b/app/controllers/concerns/district_authenticated.rb
@@ -13,7 +13,7 @@ module DistrictAuthenticated
 
   def authenticated_district
     @_authenticated_district ||= authenticate_with_http_basic do |user, pass|
-      District.find_by(slug: user, api_secret: pass)
+      District.active.find_by(slug: user, api_secret: pass)
     end
   end
 end

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -31,6 +31,10 @@ class District < ActiveRecord::Base
   auto_strip_attributes :name, :contact_phone, squish: true
   auto_strip_attributes :contact_email, delete_whitespaces: true
 
+  def self.active
+    where(is_active: true)
+  end
+
   private
 
   def assign_api_secret

--- a/app/models/zonar.rb
+++ b/app/models/zonar.rb
@@ -24,7 +24,7 @@ class Zonar
   TIME_HEADER_PATTERN = /^Time\(([A-Z]+)\)$/
 
   READ_TIMEOUT = 5.seconds
-  REQUEST_INTERVAL = 20.seconds
+  REQUEST_INTERVAL = 15.seconds
   MAX_REQUEST_WINDOW = 2.minutes
   CIRCUIT_RETRY_INTERVAL = 1.minute
 

--- a/db/migrate/20151209155857_add_is_active_to_districts.rb
+++ b/db/migrate/20151209155857_add_is_active_to_districts.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToDistricts < ActiveRecord::Migration
+  def change
+    add_column :districts, :is_active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151118155406) do
+ActiveRecord::Schema.define(version: 20151209155857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,20 +72,21 @@ ActiveRecord::Schema.define(version: 20151118155406) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "districts", force: :cascade do |t|
-    t.text     "name",              null: false
-    t.text     "slug",              null: false
-    t.text     "contact_phone",     null: false
-    t.text     "contact_email",     null: false
-    t.text     "api_secret",        null: false
-    t.text     "zonar_customer",    null: false
-    t.text     "zonar_username",    null: false
-    t.text     "zonar_password",    null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.string   "logo_file_name",    null: false
-    t.string   "logo_content_type", null: false
-    t.integer  "logo_file_size",    null: false
-    t.datetime "logo_updated_at",   null: false
+    t.text     "name",                             null: false
+    t.text     "slug",                             null: false
+    t.text     "contact_phone",                    null: false
+    t.text     "contact_email",                    null: false
+    t.text     "api_secret",                       null: false
+    t.text     "zonar_customer",                   null: false
+    t.text     "zonar_username",                   null: false
+    t.text     "zonar_password",                   null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.string   "logo_file_name",                   null: false
+    t.string   "logo_content_type",                null: false
+    t.integer  "logo_file_size",                   null: false
+    t.datetime "logo_updated_at",                  null: false
+    t.boolean  "is_active",         default: true, null: false
   end
 
   add_index "districts", ["api_secret"], name: "index_districts_on_api_secret", unique: true, using: :btree

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -7,7 +7,7 @@ module Clockwork
   end
 
   every(Zonar::REQUEST_INTERVAL, 'UpdateBusLocations') do
-    District.find_each do |district|
+    District.active.find_each do |district|
       UpdateBusLocationsJob.perform_later(district)
     end
   end

--- a/spec/features/landing_page_spec.rb
+++ b/spec/features/landing_page_spec.rb
@@ -28,4 +28,13 @@ feature 'Landing page' do
 
     expect(page).to have_content 'DISTRICT NOT FOUND'
   end
+
+  scenario 'shows an error message when the relevant district is inactive' do
+    create(:district, slug: 'bar', is_active: false)
+    use_subdomain 'bar'
+
+    visit root_path
+
+    expect(page).to have_content 'DISTRICT NOT FOUND'
+  end
 end

--- a/spec/requests/v0/assignments_spec.rb
+++ b/spec/requests/v0/assignments_spec.rb
@@ -34,6 +34,14 @@ describe 'v0 assignments API' do
 
       expect(response.status).to be 401
     end
+
+    it 'fails if the district is inactive' do
+      district = create(:district, is_active: false)
+
+      get api_v0_assignment_path('3' * 64), nil, auth_headers(district)
+
+      expect(response.status).to be 401
+    end
   end
 
   describe 'create endpoint' do
@@ -65,6 +73,14 @@ describe 'v0 assignments API' do
       request_data = { assignments: [] }
 
       post api_v0_assignments_path, request_data.as_json, invalid_auth_headers
+
+      expect(response.status).to be 401
+    end
+
+    it 'fails if the district is inactive' do
+      district = create(:district, is_active: false)
+
+      post api_v0_assignments_path, {}, auth_headers(district)
 
       expect(response.status).to be 401
     end


### PR DESCRIPTION
This allows us to leave districts "inactive" on staging unless we currently need them, so both staging and production will not be making redundant requests for the same Zonar data.
