### PR TITLE
Fix student label per-user uniqueness validation

### DIFF
--- a/app/models/student_label.rb
+++ b/app/models/student_label.rb
@@ -20,6 +20,8 @@ class StudentLabel < ActiveRecord::Base
   private
 
   def student_must_be_unique_to_user
-    errors.add(:digest, 'taken') if StudentLabel.exists?(student_id: student_id)
+    if user.student_labels.where(student_id: student_id).where.not(id: id).any?
+      errors.add(:digest, 'taken')
+    end
   end
 end

--- a/spec/models/student_label_spec.rb
+++ b/spec/models/student_label_spec.rb
@@ -9,5 +9,25 @@ describe StudentLabel do
 
       expect(student_label).to_not be_valid
     end
+
+    it 'enforces uniqueness of the student per-user as a "digest" validation' do
+      user = create(:user)
+      student = create(:student)
+      create(:student_label, student: student, user: user)
+
+      student_label = build(:student_label, student: student, user: user)
+
+      expect(student_label).to_not be_valid
+      expect(student_label.errors[:digest]).to eq ['taken']
+    end
+
+    it 'allows the same student to be associated with multiple users' do
+      student = create(:student)
+      create(:student_label, student: student)
+
+      student_label = build(:student_label, student: student)
+
+      expect(student_label).to be_valid
+    end
   end
 end


### PR DESCRIPTION
The initial (totally untested) implementation checked for a duplicate student among all student labels that exist, instead of just the same user's student labels. Now it's fixed and more-tested.
