### PR TITLE
Refer to branch instead of SHA for ember-i18n fork

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,7 @@
     "ember-disable-proxy-controllers": "1.0.1",
     "ember-export-application-global": "1.0.5",
     "ember-font-awesome": "2.1.1",
-    "ember-i18n": "git://github.com/grantovich/ember-i18n.git#9e840285b53879e5a1eeb7fca57076b69b6f8c9b",
+    "ember-i18n": "grantovich/ember-i18n#locale-override",
     "ember-i18n-errors": "0.2.0",
     "ember-intercom": "0.0.2",
     "ember-leaflet": "2.2.6",


### PR DESCRIPTION
It occurred to me that since Schoolbot is using a work-in-progress branch from my personal fork of `ember-i18n`, the specific SHA it was referencing probably didn't exist anymore, which would cause deployments to fail. It turns out you can reference branches by name in `package.json`, an approach that's immune to SHAs being rebased out of existence.