### PR TITLE
Upgrade CI environment to 14.04 image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,22 @@
+# Reference for QT 5.5 configuration:
+# https://discuss.circleci.com/t/containers-running-out-of-memory-on-14-04-image-but-runs-fine-on-12-04/4475/9
+# https://discuss.circleci.com/t/using-qt-5-with-circleci/88/19
+
 machine:
   environment:
     RAILS_ENV: test
-    QMAKE: /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+    QMAKE: /opt/qt55/bin/qmake
   node:
     version: 5
+  services:
+    - redis
 checkout:
   post:
     - cp .sample.env .env
     - cp client/.sample.env client/.env
 dependencies:
   pre:
-    - sudo apt-get update -y; true
-    - sudo apt-get install apt -y
-    - sudo apt-get -y install qt5-default qt5-qmake qtbase5-dev libqt5webkit5-dev
-    - echo "/opt/qt5/bin/qt5-env.sh" >> ~/.circlerc
+    - echo 'source /opt/qt55/bin/qt55-env.sh' >> /home/ubuntu/.circlerc
   override:
     - bundle config --local path .bundle
     - bundle config --local without development

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     RAILS_ENV: test
-    QMAKE: /opt/qt55/bin/qmake
+    QMAKE: /opt/qt5/bin/qmake
   node:
     version: 5
 checkout:
@@ -10,11 +10,10 @@ checkout:
     - cp client/.sample.env client/.env
 dependencies:
   pre:
-    - sudo apt-get install apt -y
-    - sudo add-apt-repository ppa:beineri/opt-qt551 -y
     - sudo apt-get update -y; true
-    - sudo apt-get install -y qt55webkit libwebkit-dev libgstreamer0.10-dev
-    - echo "/opt/qt55/bin/qt55-env.sh" >> ~/.circlerc
+    - sudo apt-get install apt -y
+    - sudo apt-get -y install qt5-default qt5-qmake qtbase5-dev libqt5webkit5-dev
+    - echo "/opt/qt5/bin/qt5-env.sh" >> ~/.circlerc
   override:
     - bundle config --local path .bundle
     - bundle config --local without development

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     RAILS_ENV: test
-    QMAKE: /opt/qt5/bin/qmake
+    QMAKE: /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   node:
     version: 5
 checkout:


### PR DESCRIPTION
Until now our Circle builds were running in an environment based on Ubuntu 12.04, which is, uh, [old](https://en.wikipedia.org/wiki/Ubuntu_version_history#Version_timeline) (though still supported until April of this year). For a while Circle offered an "experimental" toggle to use a 14.04-based image, which didn't work very well back when we first tried it. Happily this feature is no longer experimental and in fact works great for us with only a few changes required.

[The switch](https://cloud.githubusercontent.com/assets/394835/23097674/7b6cd70a-f607-11e6-9171-f0fcd0a5077c.png) is global and I've already flipped it, so this PR is just adapting to the new environment. Most importantly, :tada: Qt 5.5 is installed by default! :tada: but is not the "default Qt" so a few tweaks are needed.