### PR TITLE
Update rails-dom-testing to resolve Nokogiri vuln

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,11 +119,11 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.7.0)
+    i18n (0.8.1)
     intercom (3.5.5)
       json (~> 1.8)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (1.8.6)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -138,10 +138,10 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.1)
     netrc (0.11.0)
     newrelic_rpm (3.16.3.323)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     paperclip (5.1.0)
       activemodel (>= 4.2.0)
@@ -180,9 +180,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -261,9 +261,9 @@ GEM
     test_after_commit (1.1.0)
       activerecord (>= 3.2)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timecop (0.8.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -334,4 +334,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.3
+   1.14.6


### PR DESCRIPTION
This resolves the bundle-audit failure on CI. Note this does not indicate a real security vulnerability for us, since in our case Nokogiri is only a dependency of `rails-dom-testing` and thus not used in production.