### PR TITLE
Switch to intercom token due to deprecation

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -11,5 +11,4 @@ AWS_BUCKET=schoolbot-uploads
 AWS_ACCESS_KEY=access-key
 AWS_SECRET_KEY=access-secret
 INTERCOM_ID=12345678
-INTERCOM_API_KEY=intercom_api_key
-INTERCOM_SECRET=intercom_secret
+INTERCOM_TOKEN=intercom_token

--- a/app/jobs/intercom_update_job.rb
+++ b/app/jobs/intercom_update_job.rb
@@ -55,7 +55,7 @@ class IntercomUpdateJob < ActiveJob::Base
   def intercom
     @_intercom ||= Intercom::Client.new(
       app_id: ENV.fetch('INTERCOM_ID'),
-      api_key: ENV.fetch('INTERCOM_API_KEY')
+      token: ENV.fetch('INTERCOM_TOKEN')
     )
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -16,7 +16,7 @@ class UserSerializer < ActiveModel::Serializer
     if INTERCOM_ENABLED
       OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha256'),
-        ENV.fetch('INTERCOM_SECRET'),
+        ENV.fetch('INTERCOM_TOKEN'),
         object.id.to_s
       )
     end


### PR DESCRIPTION
API Keys are going to be deprecated and replaced with tokens.