### PR TITLE
Revert intercom secret removal

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -16,7 +16,7 @@ class UserSerializer < ActiveModel::Serializer
     if INTERCOM_ENABLED
       OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha256'),
-        ENV.fetch('INTERCOM_TOKEN'),
+        ENV.fetch('INTERCOM_SECRET'),
         object.id.to_s
       )
     end


### PR DESCRIPTION
Should not have removed the secret key from intercom.
https://docs.intercom.com/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product